### PR TITLE
Changed references to SkyBet to SB&G

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-Skybet Engineering Site
-=======================
+Sky Betting and Gaming Engineering Site
+=======================================
 
-This is source for our public engineering site at http://engineering.skybettingandgaming.com rendered via Jeykll through Github Pages.
+This is source for our public engineering site at http://engineering.skybettingandgaming.com, rendered via Jeykll through Github Pages.
 
 ### How to Contribute
 
@@ -15,7 +15,7 @@ All changes are welcome from additional articles, to styling changes, etc. If yo
 
 ### Rendering the Site Locally
 
-To render the site locally you need to [install Jekyll](https://jekyllrb.com/docs/installation/) & the jekyll feed gem (`gem install jekyll-feed`). Then `cd` into your cloned repository and run `jeykll serve` which will result in the site being available on `http://127.0.0.1:4000/`, rerednering if you make any changes.
+To render the site locally you need to [install Jekyll](https://jekyllrb.com/docs/installation/) & the jekyll feed gem (`gem install jekyll-feed`). Then `cd` into your cloned repository and run `jeykll serve` which will result in the site being available on `http://127.0.0.1:4000/`, re-rendering if you make any changes.
 
 ### Adding a new Article
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,6 +5,6 @@
  <meta name=viewport content="width=device-width,initial-scale=1.0">	
  <link rel="stylesheet" href="/css/basic.css" type="text/css">
  <link rel="alternate" 
-       type="application/atom+xml" title="Sky Bet Engineering Feed" 
+       type="application/atom+xml" title="Sky Betting and Gaming Engineering Feed" 
        href="{{ site.url | xml_escape }}/feed.xml" />
 </head>

--- a/_posts/2015-01-20-parsing-json-in-hive.md
+++ b/_posts/2015-01-20-parsing-json-in-hive.md
@@ -6,7 +6,7 @@ date:       2015-01-20 14:10:00
 summary:    5 different approaches to handling JSON data with Hive. 
 ---
 
-In the Sky Bet data team we were recently asked to keep records of business events that are of interest to our analysts in our Hive data warehouse. These events are delivered in files containing JSON structures (1 JSON object per event). JSON's simplicity and ubiquitous nature has made it the weapon of choice for data interchange in recent times and this means that, as a Hive developer, it’s likely that you are going to encounter JSON format data at some point. Hive provides two main mechanisms for dealing with this, JSON UDFs (of which there are two) and JSON SerDes (of which there are many but they all do a similar thing). The below outlines 5 different approaches and provides a guide as to the situations in which each is optimal.
+In the Sky Betting and Gaming data team we were recently asked to keep records of business events that are of interest to our analysts in our Hive data warehouse. These events are delivered in files containing JSON structures (1 JSON object per event). JSON's simplicity and ubiquitous nature has made it the weapon of choice for data interchange in recent times and this means that, as a Hive developer, it’s likely that you are going to encounter JSON format data at some point. Hive provides two main mechanisms for dealing with this, JSON UDFs (of which there are two) and JSON SerDes (of which there are many but they all do a similar thing). The below outlines 5 different approaches and provides a guide as to the situations in which each is optimal.
 
 ### 1. Store the JSON directly and parse it at query time
 
@@ -23,7 +23,7 @@ The disadvantage to this approach is pretty obvious, Hive will need to parse the
 ### 2. Use the get_json_object UDF when unstaging
 
 Let’s say that performance is a primary concern and that we have a well-defined JSON structure that is unlikely to change. In this case the query time parsing approach is very inefficient but but we can still use the UDFs at the point of data insertion to create Hive columns from JSON fields. In particular the `get_json_object` UDF is designed to parse a JSON string and return fields. It takes two arguments, a column containing the raw JSON string and an argument detailing the field to be selected (dot notation where `$` is the root).
-At SkyBet we have a best practice to stage all raw data that is ingested into the data warehouse before unstaging it into more useful table structures. In this case the raw JSON is staged into a table in string format and then unstaged using the get_json_object UDF into a destination table. The example for this is very similar to the query above except that it inserts the results into a separate table rather than displaying them to the user. This means this query only need be run once and subsequent selects can be done from the destination table:
+At SB&G, we have a best practice to stage all raw data that is ingested into the data warehouse before unstaging it into more useful table structures. In this case the raw JSON is staged into a table in string format and then unstaged using the get_json_object UDF into a destination table. The example for this is very similar to the query above except that it inserts the results into a separate table rather than displaying them to the user. This means this query only need be run once and subsequent selects can be done from the destination table:
 
     INSERT INTO TABLE destination_table
       SELECT get_json_object(business_events_raw.json,$.event_date) event_date,
@@ -101,8 +101,8 @@ The general rules for approach selection are:
 * When you have a clearly defined but complex JSON structure you should use either the SerDe or a UDF in a stage/unstage process. The choice between these two really depends on the ingest requirements (for high speed ingest use the SerDe) and querying patterns (for a defined query pattern that could be optimized using HDFS file formats then use the UDF).
 * When your JSON structure simple key/value and you are using UDFs to parse it, favour json_tuple over get_json_object.
 
-For the Sky Bet problem described in the second paragraph we found that the data structures we would be parsing were clearly defined and simple key/value structures. We also found that there was a defined query behavior whose optimization should be given precedence over ingest speed. For these reasons we chose to use the json_tuple UDF combined with a stage/unstage process.
+For our specific problem described in the second paragraph we found that the data structures we would be parsing were clearly defined and simple key/value structures. We also found that there was a defined query behavior whose optimization should be given precedence over ingest speed. For these reasons we chose to use the json_tuple UDF combined with a stage/unstage process.
 
-As Cloudera users we may have to revisit this issue at Sky Bet in the near future thanks to items on the Impala roadmap. 2015 promises enhanced query features for nested structures and enhancements to the parquet storage format that almost certainly will invite some new approaches to this problem.
+As Cloudera users we may have to revisit this issue at SB&G in the near future thanks to items on the Impala roadmap. 2015 promises enhanced query features for nested structures and enhancements to the parquet storage format that almost certainly will invite some new approaches to this problem.
 
 I hope this sheds some light on some of the concerns surrounding the use of JSON in Hive, as always we appreciate your comments and feedback.

--- a/_posts/2015-01-26-kanban-geological-record.md
+++ b/_posts/2015-01-26-kanban-geological-record.md
@@ -6,11 +6,11 @@ date:       2015-01-26 16:15:30
 summary:    Ian Carroll's commentary on tracking the record of workflow by looking at the Kanban cards coming off the boards.
 ---
 
-[Ian Carroll](http://iancarroll.com/) has been working with SkyBet to improve our Agile processes. Read his thoughts on balanced investment in a growing business using Kanban.
+[Ian Carroll](http://iancarroll.com/) has been working with SB&G to improve our Agile processes. Read his thoughts on balanced investment in a growing business using Kanban.
 
 ![Kanban Cards](/images/iancarroll-kanban-cards.jpg)
 
 Originally posted on [iancarroll.com](http://iancarroll.com/2015/01/23/kanbans-geological-record/):
 
-> Craig Watson ([@craigwatsonuk](https://twitter.com/craigwatsonuk)) from SkyBet has been hoarding away the cards that flow across his teams card wall for many months. He’s kept them in the exact order they were completed. Craig explains “it’s like a geological record of the Kanban system”. As a very general guide, blue cards are platform related, yellow cards are new features, and pink are defects / tech debt. We see a lot of pink throughout the record which for me is a healthy sign that trade-off decisions (aka tech debt) and live defects/incidents are getting the attention they need. We can see bands of yellow and blue throughout the record signifying a specific change in selection policy for work entering the team.
+> Craig Watson ([@craigwatsonuk](https://twitter.com/craigwatsonuk)) from Bet Tribe has been hoarding away the cards that flow across his teams card wall for many months. He’s kept them in the exact order they were completed. Craig explains “it’s like a geological record of the Kanban system”. As a very general guide, blue cards are platform related, yellow cards are new features, and pink are defects / tech debt. We see a lot of pink throughout the record which for me is a healthy sign that trade-off decisions (aka tech debt) and live defects/incidents are getting the attention they need. We can see bands of yellow and blue throughout the record signifying a specific change in selection policy for work entering the team.
 > [Read More...](http://iancarroll.com/2015/01/23/kanbans-geological-record/)

--- a/_posts/2015-02-18-paul-mc-agile-yorkshire.md
+++ b/_posts/2015-02-18-paul-mc-agile-yorkshire.md
@@ -8,7 +8,7 @@ summary:    A talk about the importance of forming product teams and investment 
 
 Paul McCormick presented at [Agile Yorkshire](http://www.agileyorkshire.org/), his summary:
 
-> How SkyBet is moving away from looking at work as projects to themes of investment across their delivery teams. SkyBet has found that delivering against deadline projects overtime comes at a cost, even when using agile or lean methodologies.
+> How Sky Betting and Gaming is moving away from looking at work as projects to themes of investment across their delivery teams.  SB&G has found that delivering against deadline projects overtime comes at a cost, even when using agile or lean methodologies.
 
 [Download slides as PDF](/pdf/agile-yorkshire-projects-to-investment-themes.pdf)
 

--- a/_posts/2015-04-20-devopsdays-paris.md
+++ b/_posts/2015-04-20-devopsdays-paris.md
@@ -60,7 +60,7 @@ The winning topics are then distributed over 30min slots in different areas of t
 
 #### Monitoring as code
 
-This discussion focused around the different ways to monitor applications and infrastructure. I'm very pleased to find that SkyBet are very much in the “advanced” bracket when it comes to monitoring from alerting, metrics, sharing and business dashboards. But it’s interesting to see how some organisations are using log monitoring (ELK stacks etc) to monitor more than just logs.
+This discussion focused around the different ways to monitor applications and infrastructure. I'm very pleased to find that SB&G are very much in the “advanced” bracket when it comes to monitoring from alerting, metrics, sharing and business dashboards. But it’s interesting to see how some organisations are using log monitoring (ELK stacks etc) to monitor more than just logs.
 
 #### Why ? Ansible or Puppet or Chef
 
@@ -68,7 +68,7 @@ This turned into quite a heated debate about the selection of an Infrastructure 
 
 #### Microservices a support nightmare?
 
-I suggested this open space to gauge opinion of micro services. I explained a situation at SkyBet where a legacy application was in part being replaced by micro services. There were a number of extremely smart people in the room (including Patrick DeBois) they explained so long as the necessary testing and monitoring was in place it should really help (which we do, the group concluded in my case that there was nothing to worry about (and that we have a great dev team)). The rest of the discussion focused on the practicalities of implementing micro services and how they could simplify development , in some cases they encourage organizational change (anti Conways Law), but they weren’t a silver bullet and under some circumstances aren’t appropriate (e,g, transactional rollback).
+I suggested this open space to gauge opinion of micro services. I explained a situation in Bet Tribe where a legacy application was in part being replaced by micro services. There were a number of extremely smart people in the room (including Patrick DeBois) they explained so long as the necessary testing and monitoring was in place it should really help (which we do, the group concluded in my case that there was nothing to worry about (and that we have a great dev team)). The rest of the discussion focused on the practicalities of implementing micro services and how they could simplify development , in some cases they encourage organizational change (anti Conways Law), but they weren’t a silver bullet and under some circumstances aren’t appropriate (e,g, transactional rollback).
 
 ### Day Two
 

--- a/_posts/2015-09-09-opensourcing-pidl.md
+++ b/_posts/2015-09-09-opensourcing-pidl.md
@@ -14,7 +14,7 @@ A single job may involve using Sqoop or HDFS to put data in place, the executing
 
 Like many old data warehouses, shell scripting has been the norm for orchestrating scripts, queries, imports and exports. There are many problems with shell scripts, not least that you don't necessarily know something is wrong until most of the job is already done and a syntax error catches you out. Parallelism is difficult, and getting to grips with even bash's relatively simple control flow syntax is enough to give you a headache.
 
-The primary method of orchestrated workflows for Hadoop within SkyBet is by running pipelines of commands that manipulate data in a variety of ways. Pidl is a Pipeline Definition Language intended to make describing these
+The primary method of orchestrated workflows for Hadoop within SB&G is by running pipelines of commands that manipulate data in a variety of ways. Pidl is a Pipeline Definition Language intended to make describing these
 pipelines concise and consistent while being flexible enough to handle any
 behavioural requirement.
 


### PR DESCRIPTION
I tried to be diverse with my changes to keep it interesting rather than parroting "Sky Betting and Gaming" everywhere...

Rob, I am assuming you are the only one who is able to change the title of the repo in Github itself to: "Sky Betting and Gaming Engineering Blog & Site http://engineering.skybettingandgaming.com"