### PR TITLE
adds missing anemone dependency for checking links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,6 @@ source "https://rubygems.org"
 
 gem 'rake'
 gem 'github-pages'
+group :development do
+  gem 'anemone'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,9 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.8)
+    anemone (0.7.2)
+      nokogiri (>= 1.3.0)
+      robotex (>= 1.0.0)
     blankslate (2.1.2.4)
     classifier-reborn (2.0.4)
       fast-stemmer (~> 1.0)
@@ -119,6 +122,7 @@ GEM
       ffi (>= 0.5.0)
     rdiscount (2.1.8)
     redcarpet (3.3.3)
+    robotex (1.0.0)
     safe_yaml (1.0.4)
     sass (3.4.20)
     sawyer (0.6.0)
@@ -138,6 +142,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  anemone
   github-pages
   rake
 


### PR DESCRIPTION
The anemone gem is required for running `bundle exec rake check_links` so I've added it as a dependency in the development group (which I'm hoping github pages will ignore).