### PR TITLE
add multi-author support

### DIFF
--- a/_includes/author.html
+++ b/_includes/author.html
@@ -40,8 +40,12 @@
 
     {% if page.className == 'authors' %}
     <h3 class="author-articles">Articles by {{ author.name | truncatewords:1,"" }}</h3>
-    {% for post in articles %}
-     {% include postSummary.html %}
+
+    {% for post in site.posts %}
+      {% if post.author contains key %}
+        {% include postSummary.html %}
+      {% endif %}
     {% endfor %}
+
     {% endif %}
 </section>

--- a/_includes/postSummary.html
+++ b/_includes/postSummary.html
@@ -3,10 +3,6 @@
 {% assign minutes = 1 %}
 {% endif %}
 
-{% if post.author %}
-{% assign author = site.data.authors[post.author] %}
-{% endif %}
-
 <div class="post">
     <div class="date">
         <time datetime="{{ post.date | date: "%Y-%m-%d" }}">
@@ -23,19 +19,31 @@
     </div>
     {% endif %}
 
-    {{ post.summary | markdownify }}
+    {{ post.summary }}
 
     <div class="cta flex">
-        {% if post.author %}
         <div class="author flex-item">
             <header>Author:</header>
             <p>
-                {% if page.className != 'authors' %}<a href="/authors#{{ post.author }}">{% endif %}
-                    {{ author.name }}
-                {% if page.className != 'authors' %}</a>{% endif %}
-            </p>
-        </div>
+        {% assign authorCount = post.author | size %}
+        {% if authorCount == 0 %}
+        No author
+        {% elsif authorCount == 1 %}
+        {{ post.author | first }}
+        {% else %}
+        {% for author in post.author %}
+        {% if forloop.first %}
+        {{ author }}
+        {% elsif forloop.last %}
+        and {{ author }}
+        {% else %}
+        , {{ author }}
         {% endif %}
+        {% endfor %}
+        {% endif %}
+            </p>
+            </div>
+
         {% if post.category %}
         <div class="categories flex-item">
             <header>Category:</header>

--- a/_includes/postSummary.html
+++ b/_includes/postSummary.html
@@ -23,24 +23,28 @@
 
     <div class="cta flex">
         <div class="author flex-item">
+            {% assign authorCount = post.author | join: "," | split: "," | size %}
+            {% if authorCount > 1 # pluralize filter not working as expected %}
+            <header>Authors:</header>
+            {% else %}
             <header>Author:</header>
+            {% endif %}
+
             <p>
-        {% assign authorCount = post.author | size %}
-        {% if authorCount == 0 %}
-        No author
-        {% elsif authorCount == 1 %}
-        {{ post.author | first }}
-        {% else %}
-        {% for author in post.author %}
-        {% if forloop.first %}
-        {{ author }}
-        {% elsif forloop.last %}
-        and {{ author }}
-        {% else %}
-        , {{ author }}
-        {% endif %}
-        {% endfor %}
-        {% endif %}
+            {% if post.author == empty %}
+            No author
+            {% else %}
+              {% for a in post.author %}
+                {% assign author=site.data.authors[a] %}
+                {% if forloop.first %}
+                  <a href="/authors#{{ a }}">{{ author.name }}</a>
+                {% elsif forloop.last %}
+                  and <a href="/authors#{{ a }}">{{ author.name }}</a>
+                {% else %}
+                  , <a href="/authors#{{ a }}">{{ author.name }}</a>
+                {% endif %}
+              {% endfor %}
+            {% endif %}
             </p>
             </div>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -38,12 +38,18 @@ fixedHeader: true
     </section>
 
     <aside class="grid-xs-s-1-1 grid-m-xl-1-3">
-        {% if author %}
-        {% assign key=page.author %}
+
+        {% assign authorCount = page.author | size %}
+        {% if authorCount == 0 %}
+        <!-- No author -->
+        {% else %}
         <div class="meet-author">
             <h3>Meet the author</h3>
-
+            {% for a in page.author %}
+            {% assign key=a %}
+            {% assign author=site.data.authors[a] %}
             {% include author.html %}
+            {% endfor %}
         </div>
         {% endif %}
 

--- a/_layouts/raw.html
+++ b/_layouts/raw.html
@@ -30,9 +30,7 @@ isArticle: false
             <ul>
             {% for key in sortedAuthors %}
              {% assign author = site.data.authors[key] %}
-             {% assign articles = (site.posts | where: "author",key %}
-             {% if articles != empty and author.hasLeft != true %}
-
+             {% unless author.hasLeft %}
               {% if author.image %}
                   <li class="author--image" title="{{author.name}}">
                       <a href="/authors#{{ key }}">
@@ -40,7 +38,7 @@ isArticle: false
                       </a>
                   </li>
               {% endif %}
-             {% endif %}
+             {% endunless %}
             {% endfor %}
             </ul>
         </div>

--- a/authors/index.html
+++ b/authors/index.html
@@ -12,15 +12,11 @@ fixedHeader: true
 
 <div class="meet-author">
     {% for keyedAuthor in site.data.authors %}
-    {% assign key = keyedAuthor[0] %}
-    {% assign author = keyedAuthor[1] %}
-    {% assign articles = (site.posts | where: "author",key %}
+      {% assign key = keyedAuthor[0] %}
+      {% assign author = keyedAuthor[1] %}
 
-    {% if articles != empty %}
-    <div class="author-section hide">
+      <div class="author-section hide">
         {% include author.html %}
-    </div>
-    {% endif %}
+      </div>
     {% endfor %}
-
 </div>


### PR DESCRIPTION
OK tell me what I've broken with this.

You can add multiple authors in the post frontmatter as follows

```
author:
 - alice_kaerast
 - dan_adams
```

Existing posts do not need changing, and you can even have posts without an author should you so wish.

Be aware I've discovered an existing bug while developing this, my editor (Rubymine) has a tendency to add additional dashes after the frontmatter and rendering breaks if there aren't exactly three of them.