### PR TITLE
NodeConf London post: branding and grammar fixes

### DIFF
--- a/_posts/2016-05-18-looking-back-at-nodeconf-london.md
+++ b/_posts/2016-05-18-looking-back-at-nodeconf-london.md
@@ -3,13 +3,13 @@ layout:     post
 title:      Looking back at NodeConf London
 author:     ian_thomas
 date:       2016-05-18 09:00:00
-summary:    It’s a little known fact that skybet.com has been working with node.js since version 0.4 (though our first app running in a live environment was on version 0.6) so we’ve got a long history of running JavaScript on the server. In addition, our customer experience is wholly reliant on JavaScript in the browser so you could say we’re less of a PHP shop and more of a JavaScript shop… So it was with interest that three of the skybet.com team headed to that London for the first ever NodeConf London.
+summary:    It’s a little known fact that skybet.com has been working with Node.js since version 0.4 (though our first app running in a live environment was on version 0.6) so we’ve got a long history of running JavaScript on the server. In addition, our customer experience is wholly reliant on JavaScript in the browser so you could say we’re less of a PHP shop and more of a JavaScript shop… So it was with interest that three of the skybet.com team headed to that London for the first ever NodeConf London.
 category:   Node.js
 image:      nodeconf-london.jpg
 tags:       node.js, conferences, community
 ---
 
-NodeConf London was billed as a single track conference “aimed at software experts at all levels of their node.js journey, from coding right up to C-level decision making”. The day was focused around four themes:
+NodeConf London was billed as a single track conference “aimed at software experts at all levels of their Node.js journey, from coding right up to C-level decision making”. The day was focused around four themes:
 
 1. Start it
 2. Build it
@@ -28,13 +28,13 @@ With all the talks available on [YouTube](https://www.youtube.com/playlist?list=
 
 As a large technology company in the north of England we can easily forget just how good we are at the things we do day to day. To qualify that statement, we have high standards and sometimes it seems we’re constantly finding code or technologies that need improvement or processes that feel outdated. We need to keep some perspective!
 
-Many of the more practical talks covered topics and ideas that have long been considered best-practise by our teams. Areas such as automation, continuous delivery, high performance code, service resilience, testability, SOA and cloud infrastructure all featured strongly on the day and are staples of our working practice.
+Many of the more practical talks covered topics and ideas that have long been considered best-practice by our teams. Areas such as automation, continuous delivery, high performance code, service resilience, testability, SOA and cloud infrastructure all featured strongly on the day and are staples of our working practice.
 
-Personally, the most impressive thing of all is our ability to execute at this level while under the scrutiny of the most stringent industry regulators. It would be easy to drown in red tape and process to avoid compliance issues but we work in an agile and reactive way with daily releases and it all feels very straightforward. Anyway, a digression away from node!
+Personally, the most impressive thing of all is our ability to execute at this level while under the scrutiny of the most stringent industry regulators. It would be easy to drown in red tape and process to avoid compliance issues but we work in an agile and reactive way with daily releases and it all feels very straightforward. Anyway, a digression away from Node!
 
 ### Idiomatic code is important
 
-Some of the talks showcased incredible performance hacks using lesser known features of JavaScript - many of which are actively denounced as being bad practise and insecure if used incorrectly. It feels like there is a net loss to implementing features using these tricks despite the performance gains and there are better ways for teams to scale their node.js applications.
+Some of the talks showcased incredible performance hacks using lesser known features of JavaScript - many of which are actively denounced as being bad practice and insecure if used incorrectly. It feels like there is a net loss to implementing features using these tricks despite the performance gains and there are better ways for teams to scale their Node.js applications.
 
 The runtime is improving quickly and can perform incredible optimisation when a developer sticks to the idiomatic coding conventions. The side-effect being code which is readable and easy to understand - factors that are essential when looking to scale a development team without reducing velocity or quality.
 
@@ -42,13 +42,13 @@ The runtime is improving quickly and can perform incredible optimisation when a 
 
 With the capabilities of transpilers (such as Babel) it’s easy to dive into using the latest language features before they arrive in the core runtime. Given the rate of change of the underlying V8 engine (and the current work to introduce Chakra Core as an alternative) it pays to focus on the supported features in the version of node you are running.
 
-Not only does this help with performance, but it also reduces the barriers to entry for working with node. The less distractions there are, the easier it is to focus on developing the core features of an application. Tooling is useful, but ultimately it distracts away from the core target of realising the value of ideas.
+Not only does this help with performance, but it also reduces the barriers to entry for working with Node. The less distractions there are, the easier it is to focus on developing the core features of an application. Tooling is useful, but ultimately it distracts away from the core target of realising the value of ideas.
 
 ### Automate platforms and infrastructure
 
 Nikhila Ravi and Luca Maraschi were particular highlights of the day speaking about serverless architecture using AWS Lambda and automated micro services infrastructure (and failover) respectively.
 
-Skybet is currently using AWS Lambda as part of the platform powering Bet Tracker and it’s a great service. Nikhila’s talk went beyond showing the strengths of Lambda’s pure function based service approach as she also showed how easily the provision and deployment of these services can be automated.
+Sky Bet is currently using AWS Lambda as part of the platform powering Bet Tracker and it’s a great service. Nikhila’s talk went beyond showing the strengths of Lambda’s pure function based service approach as she also showed how easily the provision and deployment of these services can be automated.
 
 The ability to automate the provision of services, build in resilience from the start and manage infrastructure as code are core features of a modern approach to deploying a web application so Luca’s overview of SWIM ([Scalable, Weakly consistent Infection-style process group Membership protocol](https://www.cs.cornell.edu/~asdas/research/dsn02-swim.pdf)) was really interesting. The white paper, published by Cornell University, offers more in depth information of this approach and is well worth a read.
 
@@ -60,11 +60,11 @@ Looking at the history of software engineering it’s obvious that as an industr
 
 ## A commitment to the wider community
 
-As a company we rely on JavaScript and node.js to provide core functionality across all our products so it’s only right that we should be attending and supporting events such as NodeConf.
+As a company we rely on JavaScript and Node.js to provide core functionality across all our products so it’s only right that we should be attending and supporting events such as NodeConf.
 
 JavaScript is unique in the world of Software Engineering as it is the single most ubiquitous programming language in use today thanks to modern browsers and the Internet. It’s also one of the least prescriptive in terms of how to work with it. This, added to the varying levels of feature support across myriad runtimes and the many foibles of a language primarily devised over the course of a few days makes it both a very difficult and very easy language to work with.
 
-High quality events, such as NodeConf, are vital to the ongoing success of businesses and developers, not just the runtimes and language itself. As a community we have been excellent in sharing our work through modules on github and NPM and now we must continue to showcase best-practise work through speaking and writing to ensure the positive momentum is continued.
+High quality events, such as NodeConf, are vital to the ongoing success of businesses and developers, not just the runtimes and language itself. As a community we have been excellent in sharing our work through modules on GitHub and NPM and now we must continue to showcase best-practice work through speaking and writing to ensure the positive momentum is continued.
 
 ---
 


### PR DESCRIPTION
Small grammar/spelling/capitalisation tweaks

* Skybet = Sky Bet
* node => Node
* github => GitHub
* best/bad practise => best/bad practice