### PR TITLE
Adds --future to preview posts from the future

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -122,7 +122,7 @@ desc 'Preview on local machine (server with --auto)'
 task :preview => :clean do
   compass('compile') # so that we are sure sass has been compiled before we run the server
   compass('watch &')
-  jekyll('serve --watch')
+  jekyll('serve --watch --future')
 end
 task :serve => :preview
 


### PR DESCRIPTION
The rake default task to preview locally wasn't using --future, which means posts from the future weren't shown.  I've added this flag in so now posts with a date from the future will render correctly when previewed locally.