### PR TITLE
Events page, with link to Eventbrite and the IndustryTalks Slack

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -54,15 +54,15 @@
 
             <div class="grid-xs-s-1-2 grid-m-xl-1-2 social hide-xs">
                 {% assign nav = (site.pages | where: "nav",true | sort: "nav_weight") %}
-                {% for node in nav %}
-                    <div class="{{node.nav_class}} hide slide-right">
+                <div class="{{node.nav_class}} hide slide-right">
+                    {% for node in nav %}
                         {% if page.url == node.url %}
                             <a href="{{node.url}}" class="btn btn--primary current">{{node.nav_title}}</a>
                         {% else %}
                             <a href="{{node.url}}" class="btn btn--primary {{node.nav_class}}">{{node.nav_title}}</a>
                         {% endif %}
-                    </div>
-                {% endfor %}
+                    {% endfor %}
+                </div>
                 <ul class="social-list">
                     <li><a class="fa fa-twitter" href="https://twitter.com/SBGEngineers"></a></li>
                     <li><a class="fa fa-github-alt" href="https://github.com/skybet"></a></li>

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -18,6 +18,9 @@ header.page {
         ul {
             margin: 0;
             padding: 13px 0;
+            li {
+                display: inline-block;
+            }
         }
     }
 

--- a/events/index.html
+++ b/events/index.html
@@ -1,0 +1,18 @@
+---
+layout:     raw
+title:      Events
+summary:    We host regular Tech talks in our Leeds and Sheffield offices
+nav:        true
+nav_title:  Events
+nav_weight: 1
+className:  jobs
+---
+<h2>{{ page.title }}</h2>
+
+<p>We host regular Tech talks in our Leeds and Sheffield office.</p>
+
+<p>Details of events are available on our <a href="https://www.eventbrite.co.uk/o/sky-betting-and-gaming-8286531503">Eventbrite</a> page.</p>
+
+<p>Why not join us on Slack to discuss them?</p>
+
+<script async defer src="https://sbg-slack-invite.herokuapp.com/slackin.js?large"></script>

--- a/events/index.html
+++ b/events/index.html
@@ -13,6 +13,3 @@ className:  jobs
 
 <p>Details of events are available on our <a href="https://www.eventbrite.co.uk/o/sky-betting-and-gaming-8286531503">Eventbrite</a> page.</p>
 
-<p>Why not join us on Slack to discuss them?</p>
-
-<script async defer src="https://sbg-slack-invite.herokuapp.com/slackin.js?large"></script>


### PR DESCRIPTION
On behalf of Victoria Howling...

----

The IndustryTalks Slack is a separate Slack instance from our internal one, set up by Recruitment to promote our events.
Access to this Slack is granted with Slackin.
This is currently available at the https://sbg-slack-invite.herokuapp.com URL, but ideally this will be moved to a skybettingandgaming.com domain at some point (e.g. slack.skybettingandgaming.com).


the /events page:

<img width="799" alt="screen shot 2017-01-19 at 21 56 06" src="https://cloud.githubusercontent.com/assets/1116529/22127765/5bac59ce-de95-11e6-9a7b-4c80c8b69c48.png">

and clicking on the slack button:

<img width="856" alt="screen shot 2017-01-19 at 21 56 11" src="https://cloud.githubusercontent.com/assets/1116529/22127779/6a199c74-de95-11e6-8c82-feb2b05746c1.png">

There is an outstanding issue with the header in headFixed mode though, so CSS advice would be appreciated.
The Jobs and Events buttons overlap:

<img width="433" alt="screen shot 2017-01-19 at 22 12 49" src="https://cloud.githubusercontent.com/assets/1116529/22127813/84cf750c-de95-11e6-944a-43e55168733b.png">
