### PR TITLE
Fix page jump when scrolling (sticky header)

### DIFF
--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -14,7 +14,7 @@ body {
 
     &.headFixed {
         article.grid, main {
-            padding-top: 90px;
+            padding-top: 70px;
         }
     }
 }


### PR DESCRIPTION
Adjust content padding when header is sticky so the page doesn't jump when scrolling

Padding now matches the height of the header

Fixes this: https://gyazo.com/1c62487dea8607c15b7d6420cd909791

Tested in Chrome 55.0.2883.95 and Firefox 47.0.1 on OS X