### PR TITLE
allow authors to disable comments for their post

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -87,6 +87,9 @@ className: post
     </div>
 </section>
 
+{% if page.disablecomments %}
+Comments for this post have been disabled
+{% else %}
 <script>
 (function() {
   var disqus_shortname = 'skybet';
@@ -96,5 +99,6 @@ className: post
   (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 })();
 </script>
+{% endif %}
 
 {% include footer.html %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -82,14 +82,17 @@ className: post
 <section class="comments">
     <div class="grid">
         <div class="grid-1-1">
+            {% if page.disablecomments %}
+            <div id="disqus_thread">Comments have been disabled for this post</div>
+            {% else %}
             <div id="disqus_thread"></div>
+            {% endif %}
         </div>
     </div>
 </section>
 
-{% if page.disablecomments %}
-Comments for this post have been disabled
-{% else %}
+
+{% if page.disablecomments == nil or page.disablecomments == false %}
 <script>
 (function() {
   var disqus_shortname = 'skybet';

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -92,7 +92,7 @@ className: post
 </section>
 
 
-{% if page.disablecomments == nil or page.disablecomments == false %}
+{% unless page.disablecomments %}
 <script>
 (function() {
   var disqus_shortname = 'skybet';
@@ -102,6 +102,6 @@ className: post
   (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 })();
 </script>
-{% endif %}
+{% endunless %}
 
 {% include footer.html %}


### PR DESCRIPTION
This is a simple change which allows individual posts to have comments disabled.

In place of the Disqus comment form a message would be displayed that "Comments have been disabled for this post".

I don't foresee this being used often, but might be helpful in the case of particularly controversial posts.