### PR TITLE
attempt to set title for rss feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,5 @@
 name: Sky Betting & Gaming Engineering
+title: Sky Betting & Gaming Engineering
 markdown: kramdown
 url: http://engineering.skybettingandgaming.com
 host: 0.0.0.0


### PR DESCRIPTION
The jekyll-feed gem sets the feed title based on site.title if available or site.name if not.

https://github.com/jekyll/jekyll-feed/blob/master/lib/jekyll-feed/feed.xml#L12

When you run this locally, the GitHub API is not available and therefore site.title is not set.  In this case it uses site.name which is set in _config.yml.

When you run this on GitHub Pages the GitHub API is available, and it appears to set site.title to 'skybet.github.io'

This is unexpected behaviour, and probably wants documenting or fixing somewhere else.  However for now, if my assumptions on what's happening is correct, this should fix our title on GitHub Pages.