### PR TITLE
document docker-compose as frequently broken for this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ You can now follow the rest of the instructions to render the site locally.  The
 
 ### Docker setup
 
-Whilst there is a docker-compose file to render the site locally, it is largely unsupported and frequently breaks.  The instructions below may work for you, but we are considering removing this completely.
+Whilst there is a docker-compose file to render the site locally, it is largely unsupported and frequently breaks.  We are considering removing this completely but are happy to accept a Pull Request if you can get this to work consistently.
 
 Run `docker-compose up` to launch the site in a container and after it has installed dependencies you can browse to `http://127.0.0.1:4000/`.  You can also validate your work by running `docker exec skybetgithubio_jekyll_1 rake validate`.  Docker will run a second container to generate the css from the sass, but you can also do this separately with `docker run --rm -v `pwd`:/src -p 9090:8080  -e GULP_TASK="watch" -t -i agomezmoron/docker-gulp`
 

--- a/README.md
+++ b/README.md
@@ -100,10 +100,6 @@ To render the site locally, first you need to `sudo gem install bundler`. Then y
 
 If you are making UI updates you will also need to run `npm install`, then you can then run `GULP=1 bundle exec rake` to call the gulp build with the existing set up.
 
-If you already have Docker and docker-compose installed, and don't do much Ruby work, you might find it easier to use the Docker way of running the site locally.  Run `docker-compose up` to launch the site in a container and after it has installed dependencies you can browse to `http://127.0.0.1:4000/`.  You can also validate your work by running `docker exec skybetgithubio_jekyll_1 rake validate`.  Docker will run a second container to generate the css from the sass, but you can also do this separately with `docker run --rm -v `pwd`:/src -p 9090:8080  -e GULP_TASK="watch" -t -i agomezmoron/docker-gulp`
-
-If you are doing something more than editing articles then it is possible you will need to restart the Jekyll instance or container to pick these changes up.  You shouldn't need to do this routinely while editing articles because Jekyll is called with the `--watch --future` arguments.
-
 ### Mac setup
 
 Docker and Docker Compose are the best way of rendering the site locally on a Mac because the version of Ruby is too old (2.1 is the minimum due to Nokogiri).  However, you can install a newer version of Ruby to run natively if you prefer.
@@ -118,6 +114,14 @@ Docker and Docker Compose are the best way of rendering the site locally on a Ma
 6. `gem install bundler` to install bundler
 
 You can now follow the rest of the instructions to render the site locally.  The first time you serve the site locally you'll be asked to allow ruby to listen for network connections, you should agree to this.
+
+### Docker setup
+
+Whilst there is a docker-compose file to render the site locally, it is largely unsupported and frequently breaks.  The instructions below may work for you, but we are considering removing this completely.
+
+Run `docker-compose up` to launch the site in a container and after it has installed dependencies you can browse to `http://127.0.0.1:4000/`.  You can also validate your work by running `docker exec skybetgithubio_jekyll_1 rake validate`.  Docker will run a second container to generate the css from the sass, but you can also do this separately with `docker run --rm -v `pwd`:/src -p 9090:8080  -e GULP_TASK="watch" -t -i agomezmoron/docker-gulp`
+
+If you are doing something more than editing articles then it is possible you will need to restart the Jekyll instance or container to pick these changes up.  You shouldn't need to do this routinely while editing articles because Jekyll is called with the `--watch --future` arguments.
 
 ## Validating your edits
 


### PR DESCRIPTION
The people have spoken, there's not a huge appetite to spend the time on keeping docker-compose working when it breaks so frequently.  This change makes a note that whilst there is a docker-compose file, it isn't supported and probably won't work.

Unless there's any complaints I will probably remove it completely in the future.