### PR TITLE
switch to Alice's new docker image for running rake preview

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,9 @@
 jekyll:
-    image: jekyll/jekyll
-    command: jekyll serve --watch --incremental --future
+    image: kaerast/rake-preview
     ports:
         - 4000:4000
     volumes:
-        - .:/srv/jekyll
+        - .:/usr/src/app
 gulp:
     image: agomezmoron/docker-gulp
     environment:


### PR DESCRIPTION
I've replaced the jekyll/jekyll docker image with my own which no longer does anything specific to jekyll.  Instead it provides ruby and bundler, and everything else is installed on runtime.  This is a little slower to start, but it will always provide the correct gem versions.

We should discuss where this Docker image should live (probably not in my Docker account as it currently is).  The source code for the Dockerfile is https://github.com/WheresAlice/rake-preview

This also needs some testing and probably some updates to the README.