### PR TITLE
Fix safe yaml crash in Ruby 2.5

### DIFF
--- a/spec/authors_spec.rb
+++ b/spec/authors_spec.rb
@@ -1,4 +1,5 @@
 require 'rspec'
+require 'date'
 require 'safe_yaml'
 
 authors_file = SafeYAML.load_file('_data/authors.yml')

--- a/spec/categories_spec.rb
+++ b/spec/categories_spec.rb
@@ -1,4 +1,5 @@
 require 'rspec'
+require 'date'
 require 'safe_yaml'
 
 categories_file = SafeYAML.load_file('_data/categories.yml')


### PR DESCRIPTION
Ruby 2.5 breaks the safe_yaml gem that we use in the rake validate task.  The workaround is to require 'date' before requiring 'safe_yaml' since it doesn't look like the safe_yaml issue is going to be fixed any time soon.