### PR TITLE
Add a canonical link to the https version of the blog

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,6 +11,8 @@
 <link rel="mask-icon" href="/images/favicons/safari-pinned-tab.svg" color="#5bbad5">
 <meta name="theme-color" content="#ffffff">
 
+<link rel="canonical" href="https://engineering.skybettingandgaming.com{{ page.url }}" />
+
  {% if layout.isArticle %}
  <meta property="og:type" content="article" />
  <meta property="article:published_date" content="{{ page.date | date_to_xmlschema }}" />


### PR DESCRIPTION
This also helps for any forks that search engines manage to find, redirecting them to the proper version

Note I'm deliberately using the hardcoded url rather than a variable, because in some cases (eg the site being built elsewhere) those variables get overridden.