### PR TITLE
Minor update to author info

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,7 +2,7 @@
 {% endcapture %}
 {% assign site_title = site.title | markdownify | strip_html | strip %}
 {% assign page_description = page.bio | default: page.summary | markdownify | strip_html | split: newline | first %}
-{% if page.bio %}{% assign page_title = page.name %}{% endif %}
+{% if page.layout == 'author' %}{% assign page_title = page.name %}{% endif %}
 <head>
  <meta charset="utf-8">
  <title>{{ page_title | default: page.title }}{% if page.title %} - {% endif %}{{ site_title }}</title>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -9,7 +9,7 @@ layout: null
     {% for doc in docs %}
       <url>
         <loc>{{ doc.url | replace:'/index.html','/' | absolute_url | xml_escape }}</loc>
-        <changefreq>monthly</changefreq>
+        <changefreq>{% if collection.label == 'authors' and doc.endDate %}never{% else %}monthly{% endif %}</changefreq>
         <priority>0.6</priority>
         {% if doc.last_modified_at or doc.date %}
           <lastmod>{{ doc.last_modified_at | default: doc.date | date_to_xmlschema }}</lastmod>


### PR DESCRIPTION
Fixes a couple of things:

* Author page title depended on a bio being present (everyone but 1 has one). Pages (not posts) have a `name` attribute (the file name) so can't just do `{% if page.name %}`. Everyone _does_ have `tribe` and `role` attributes, but it's ultimately safer to rely on the `layout`.
* Mark author pages in the sitemap as never changing if the author has left.